### PR TITLE
Fixing map merge with empty overrides

### DIFF
--- a/merge/merge.go
+++ b/merge/merge.go
@@ -88,6 +88,12 @@ func mergeRecursive(base, override reflect.Value) reflect.Value {
 					continue
 				}
 
+				// if there is no base value, just set the override
+				if !baseVal.IsValid() {
+					result.SetMapIndex(key, overrideVal)
+					continue
+				}
+
 				// Merge the values and set in the result
 				newVal := mergeRecursive(baseVal, overrideVal)
 				if elementsAreValues && newVal.Kind() == reflect.Ptr {

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -414,6 +414,32 @@ func TestUnit_Merge_AlternatePath_MapInterface(t *testing.T) {
 	}
 }
 
+func TestUnit_Merge_AlternatePath_MapInterfaceEmptyValue(t *testing.T) {
+	base := make(map[string]map[string]interface{})
+	base["Config"] = make(map[string]interface{})
+	base["Config"]["Test"] = "this is a test value"
+	base["Config"]["Test2"] = "this is also a test value"
+
+	override := make(map[string]map[string]interface{})
+	override["Config"] = make(map[string]interface{})
+	override["Config"]["foo"] = "bar"
+	override["Config"]["Test2"] = "baz"
+	override["Config"]["Test3"] = nil
+
+	expected := make(map[string]map[string]interface{})
+	expected["Config"] = make(map[string]interface{})
+	expected["Config"]["foo"] = "bar"
+	expected["Config"]["Test"] = "this is a test value"
+	expected["Config"]["Test2"] = "baz"
+	expected["Config"]["Test3"] = nil
+
+	ret := merge.Merge(base, override)
+
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("Actual ( %#v ) does not match expected ( %#v )", ret, expected)
+	}
+}
+
 func TestUnit_Merge_AlternatePath_StructMapStruct(t *testing.T) {
 	type testStruct struct {
 		Foo string

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -346,6 +346,26 @@ func TestUnit_Merge_AlternatePath_Map(t *testing.T) {
 	}
 }
 
+func TestUnit_Merge_AlternatePath_MapEmptyValue(t *testing.T) {
+	baseData := make(map[string]string)
+	baseData["test"] = "foo"
+	baseData["test2"] = ""
+
+	overrideData := make(map[string]string)
+	overrideData["test3"] = ""
+
+	expected := make(map[string]string)
+	expected["test"] = "foo"
+	expected["test2"] = ""
+	expected["test3"] = ""
+
+	ret := merge.Merge(baseData, overrideData)
+
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("Actual ( %#v ) does not match expected ( %#v )", ret, expected)
+	}
+}
+
 func TestUnit_Merge_AlternatePath_MapInterface(t *testing.T) {
 	base := make(map[string]map[string]interface{})
 	base["Config"] = make(map[string]interface{})

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/divideandconquer/go-merge/merge"
 )
 
+func makeStringPtr(v string) *string {
+	return &v
+}
+
 func TestUnit_Merge_BasePath(t *testing.T) {
 	a := ""
 	b := "foo"
@@ -358,6 +362,26 @@ func TestUnit_Merge_AlternatePath_MapEmptyValue(t *testing.T) {
 	expected["test"] = "foo"
 	expected["test2"] = ""
 	expected["test3"] = ""
+
+	ret := merge.Merge(baseData, overrideData)
+
+	if !reflect.DeepEqual(ret, expected) {
+		t.Errorf("Actual ( %#v ) does not match expected ( %#v )", ret, expected)
+	}
+}
+
+func TestUnit_Merge_AlternatePath_MapEmptyValuePtr(t *testing.T) {
+	baseData := make(map[string]*string)
+	baseData["test"] = makeStringPtr("foo")
+	baseData["test2"] = makeStringPtr("")
+
+	overrideData := make(map[string]*string)
+	overrideData["test3"] = makeStringPtr("")
+
+	expected := make(map[string]*string)
+	expected["test"] = makeStringPtr("foo")
+	expected["test2"] = makeStringPtr("")
+	expected["test3"] = makeStringPtr("")
 
 	ret := merge.Merge(baseData, overrideData)
 


### PR DESCRIPTION
Empty overrides will now merge into the resulting map if the base map doesn't have a value for that key.
